### PR TITLE
Added UpdateCenter component to update the position in which the map …

### DIFF
--- a/src/components/common/Map/index.js
+++ b/src/components/common/Map/index.js
@@ -1,20 +1,36 @@
-import React from 'react';
-import { MapContainer, TileLayer } from 'react-leaflet';
+import React, { useEffect } from 'react';
+import { object } from 'prop-types';
+import { MapContainer, TileLayer, useMap } from 'react-leaflet';
 
-const Map = () => {
+const UpdateCenter = ({ position }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    map.setView([position.x, position.y]);
+  }, [map, position]);
+
+  return null;
+};
+
+const Map = ({ position }) => {
   return (
     <MapContainer
       style={{ height: '100vh', width: '65%' }}
-      center={[51.505, -0.09]}
-      zoom={20}
+      center={[position.x, position.y]}
+      zoom={15}
       scrollWheelZoom={false}
     >
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+      <UpdateCenter position={position} />
     </MapContainer>
   );
+};
+
+Map.propTypes = {
+  position: object.isRequired
 };
 
 export default Map;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -36,6 +36,7 @@ export default {
   'common.about': 'About',
   'common.contact': 'Contact',
   'common.understand.button': 'Ok, got it',
+  'common.geo.confirm': 'Allow the application to use your current location',
 
   // errors
   'email.presence': 'You must enter an email to continue',

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -41,6 +41,7 @@ export default {
   'common.about': 'Acerca de',
   'common.contact': 'Contacto',
   'common.understand.button': 'Ok, lo entiendo',
+  'common.geo.confirm': 'Permitir a la aplicación utilizar su ubicación actual',
 
   // errors
   'email.presence': 'Debe ingresar un email para continuar',

--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useIntl } from 'react-intl';
 
 import Map from 'components/common/Map';
 import HomeInfo from './HomeInfo';
 
 const HomePage = () => {
   const [position, setPosition] = useState({ x: 51, y: -1 });
-  const intl = useIntl();
 
   useEffect(() => {
     if (position.x === 51 && position.y === -1) {
@@ -14,7 +12,7 @@ const HomePage = () => {
         setPosition({ x: pos.coords.latitude, y: pos.coords.longitude })
       );
     }
-  }, [position, intl]);
+  }, [position]);
 
   return (
     <div className="home-container">

--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -1,13 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
 
 import Map from 'components/common/Map';
 import HomeInfo from './HomeInfo';
 
 const HomePage = () => {
+  const [position, setPosition] = useState({ x: 51, y: -1 });
+  const intl = useIntl();
+
+  useEffect(() => {
+    if (position.x === 51 && position.y === -1) {
+      if (window.confirm(intl.formatMessage({ id: 'common.geo.confirm' }))) {
+        navigator.geolocation.getCurrentPosition(pos =>
+          setPosition({ x: pos.coords.latitude, y: pos.coords.longitude })
+        );
+      }
+    }
+  }, [position, intl]);
+
   return (
     <div className="home-container">
       <HomeInfo />
-      <Map />
+      <Map position={position} />
     </div>
   );
 };

--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -10,11 +10,9 @@ const HomePage = () => {
 
   useEffect(() => {
     if (position.x === 51 && position.y === -1) {
-      if (window.confirm(intl.formatMessage({ id: 'common.geo.confirm' }))) {
-        navigator.geolocation.getCurrentPosition(pos =>
-          setPosition({ x: pos.coords.latitude, y: pos.coords.longitude })
-        );
-      }
+      navigator.geolocation.getCurrentPosition(pos =>
+        setPosition({ x: pos.coords.latitude, y: pos.coords.longitude })
+      );
     }
   }, [position, intl]);
 


### PR DESCRIPTION
## Auto centering map on current user location

## Links (Jira/Trello ticket and other relevant links):
Trello: https://trello.com/b/77bHIxus/rootstrap-target
Figma: https://www.figma.com/file/Hlq710GJ4jCPU9EDgQS1Dx/Target-Web?node-id=0%3A788

## What & Why:
Ask for user permission to access current user location and center the Map on it every time the user logs in to his account or HomePage is re-rendered. If the user denies location access then the map will remain still on its original position.

## Tasks:
- [ ] Tested in different resolutions
- [ ] Tested with SSR
- [ ] Tested on Safari browser
- [ ] Design reviewed with design team

## Notes:

- A little workaround was needed to update Map center when it was already rendered. As official React Leaflet docs say:

_Except for its children, MapContainer props are immutable: changing them after they have been set a first time will have no effect on the Map instance or its container. The Leaflet Map instance created by the MapContainer element can be accessed by child components using one of the provided hooks or the MapConsumer component._

That's why UpdateCenter component was needed and passed as children of MapContainer.

- You can try these changes live here: http://react-app-ns.s3-website.us-east-2.amazonaws.com/