### PR TITLE
Add limit for 10 active targets at the same time

### DIFF
--- a/src/components/common/Map/NewTarget/index.js
+++ b/src/components/common/Map/NewTarget/index.js
@@ -1,17 +1,25 @@
 import { useHistory } from 'react-router-dom';
 import { useMapEvents } from 'react-leaflet';
 import { useNewTarget } from 'hooks';
+import { useSelector } from 'react-redux';
+import { useIntl } from 'react-intl';
 
 const NewTarget = () => {
   const history = useHistory();
+  const intl = useIntl();
   const { updateTargetCoords } = useNewTarget();
+  const targetsLength = useSelector(state => state.targetReducer.targets.length);
 
   useMapEvents({
     click(e) {
-      const coordinates = [e.latlng.lat, e.latlng.lng];
-      updateTargetCoords(coordinates);
-      if (history.location.pathname != '/targets/new') {
-        history.push('/targets/new');
+      if (targetsLength <= 10) {
+        const coordinates = [e.latlng.lat, e.latlng.lng];
+        updateTargetCoords(coordinates);
+        if (history.location.pathname != '/targets/new') {
+          history.push('/targets/new');
+        }
+      } else {
+        window.alert(intl.formatMessage({ id: 'target.new.restriction' }));
       }
     }
   });

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -66,6 +66,7 @@ export default {
   'target.trendTopics.travel': 'Travel',
   'target.trendTopics.music': 'Music',
   'target.delete.confirm': 'Are you sure you want to delete this target?',
+  'target.new.restriction': 'You cannot have more than 10 active targets',
 
   // feed
 

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -70,6 +70,7 @@ export default {
   'target.trendTopics.travel': 'Viajes',
   'target.trendTopics.music': 'Música',
   'target.delete.confirm': 'Está seguro que desea eliminar este objetivo?',
+  'target.new.confirm': 'No puede tener más de 10 objetivos activos',
 
   // feed
   'feed.noMatchesFound': 'Todavía no se encontraron matches para tus objetivos',


### PR DESCRIPTION
## New target limit

## What and why?

This PR adds the restriction of having a maximum of 10 active targets. The user should not be able to create a new target if there are already 10 active targets on the map.
